### PR TITLE
Add support for layman

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ mkdir /usr/local/portage
 git clone git://github.com/tbe/odroidc1-overlay.git /usr/local/portage
 echo 'PORTDIR_OVERLAY="${PORTDIR_OVERLAY} /usr/local/portage/"' >> /etc/portage/make.conf
 ```
+
+Usage with Layman
+-----------------
+```
+emerge -av layman dev-vcs/git
+pico /etc/layman/layman.cfg
+|   overlays  :
+|       https://api.gentoo.org/overlays/repositories.xml
+| +     https://github.com/tbe/odroidc1-overlay/raw/master/repositories.xml
+layman -S
+layman -a odroidc1
+```
+
 Usage with Paludis
 ------------------
 

--- a/repositories.xml
+++ b/repositories.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE repositories SYSTEM "http://www.gentoo.org/dtd/repositories.dtd">
+<repositories xmlns="" version="1.0">
+  <repo quality="experimental" status="unofficial">
+    <name>odroidc1</name>
+    <description lang="en">
+      Ebuilds for ODROID C1 nano computers.
+    </description>
+    <homepage>https://github.com/tbe/odroidc1-overlay</homepage>
+    <owner type="person">
+      <name>tbe</name>
+      <email>loki@lokis-chaos.de</email>
+    </owner>
+    <source type="git">git://github.com/tbe/odroidc1-overlay.git</source>
+    <feed></feed>
+  </repo>
+</repositories>


### PR DESCRIPTION
By adding repositories.xml, your overlay can be used with layman instead of manually in the local portage tree.
